### PR TITLE
Return selection range without size

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -7,7 +7,5 @@ module.exports = elm => {
 
   const range = selection.getRangeAt(0);
   const {startContainer: start, endContainer: end} = range;
-  const {width, height} = range.getBoundingClientRect();
-  return elm.contains(start) && elm.contains(end) && width > 0 && height > 0
-    ? range : null;
+  return elm.contains(start) && elm.contains(end) ? range : null;
 };

--- a/test.js
+++ b/test.js
@@ -30,8 +30,13 @@ test('selection, within elm & no size', t => {
   const elm = document.body.appendChild(document.createElement('div'));
   setNewSelectionRange(elm, 0, elm, 0);
   const actual = getSelectionRangeFromElm(elm);
-  const expected = null;
-  t.is(actual, expected);
+  const expectedContainer = elm;
+  const expectedStartOffset = 0;
+  const expectedEndOffset = 0;
+  t.is(actual.startContainer, expectedContainer);
+  t.is(actual.endContainer, expectedContainer);
+  t.is(actual.startOffset, expectedStartOffset);
+  t.is(actual.endOffset, expectedEndOffset);
 });
 
 test('selection, within elm & with size', t => {


### PR DESCRIPTION
Type: Major
Review: @micnews/engineers 

Changes functionality to return range even when it doesn't have a size - ie. returning the cursor position. 
